### PR TITLE
Issue in Select Option

### DIFF
--- a/components/form/Form.module.scss
+++ b/components/form/Form.module.scss
@@ -50,6 +50,23 @@ $form-muted: #ced4da;
         position: relative;
     }
 
+    .select-icon{
+        position: absolute;
+        top: 50%;
+        transform: translate(0, -50%);
+        right: 1.5em;
+        bottom: 0;
+        z-index: 5;
+        width: 1.8rem;
+        height: 2rem;
+        background-image: url("data:image/svg+xml,%3Csvg fill='%23000000' version='1.1' id='Capa_1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 94.926 94.926' xml:space='preserve'%3E%3Cg id='SVGRepo_bgCarrier' stroke-width='0'%3E%3C/g%3E%3Cg id='SVGRepo_tracerCarrier' stroke-linecap='round' stroke-linejoin='round'%3E%3C/g%3E%3Cg id='SVGRepo_iconCarrier'%3E%3Cg%3E%3Cpath d='M55.931,47.463L94.306,9.09c0.826-0.827,0.826-2.167,0-2.994L88.833,0.62C88.436,0.224,87.896,0,87.335,0 c-0.562,0-1.101,0.224-1.498,0.62L47.463,38.994L9.089,0.62c-0.795-0.795-2.202-0.794-2.995,0L0.622,6.096 c-0.827,0.827-0.827,2.167,0,2.994l38.374,38.373L0.622,85.836c-0.827,0.827-0.827,2.167,0,2.994l5.473,5.476 c0.397,0.396,0.936,0.62,1.498,0.62s1.1-0.224,1.497-0.62l38.374-38.374l38.374,38.374c0.397,0.396,0.937,0.62,1.498,0.62 s1.101-0.224,1.498-0.62l5.473-5.476c0.826-0.827,0.826-2.167,0-2.994L55.931,47.463z'%3E%3C/path%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
+        background-position: center;
+        background-size: 2em;
+        background-repeat: no-repeat;
+        content: "";
+        background-color: #f1f1ea;
+    }
+
     .category-select {
         outline: 0;
         font-size: 1rem;

--- a/components/form/form-fc.js
+++ b/components/form/form-fc.js
@@ -25,7 +25,7 @@ const FormFC = ({
 
   const categoriesSelect = Categories.map((category, i) => {
     if (i === 0) {
-      return <option key={i} value={i}>Select an activity category</option>
+      return <option key={i} value={i} hidden>Select an activity category</option>
     } else {
       return <option key={i} value={i}>{category}</option>
     }

--- a/components/form/form-fc.js
+++ b/components/form/form-fc.js
@@ -59,6 +59,10 @@ const FormFC = ({
           >
             {categoriesSelect}
           </select>
+          {
+            parseInt(category) !=0 && 
+            <a className={cx(styles['select-icon'])} onClick={()=>setCategory(0)}></a>
+          }
         </div>
       </div>
 

--- a/helpers/helpers.js
+++ b/helpers/helpers.js
@@ -21,7 +21,6 @@ const Categories = [
   'Outreach Activity',
   'Announcement',
   'Awards',
-  // 'Other'
 ]
 
 const CategoryTitles = [


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
In Select Option in new activity in submit page there was an option "Select an activity category" which was not needed so that is removed and added a button for each selected category to restore it to default
 
![Screenshot (87)](https://github.com/Pursottam6003/technodaya/assets/124811079/56fc977e-6814-48f7-a5e5-c760838daf59)
![Screenshot (86)](https://github.com/Pursottam6003/technodaya/assets/124811079/41b0f5bf-4e8c-4742-8c1c-9daca29a9ed7)
![Screenshot (85)](https://github.com/Pursottam6003/technodaya/assets/124811079/4401d20e-3d83-4643-bb74-bbe15489a995)
![Screenshot (84)](https://github.com/Pursottam6003/technodaya/assets/124811079/d25193aa-93fb-45db-8c71-d6afc85a0c7d)

<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
…
----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
