### PR TITLE
Two input fields having same name (Team -2 AARYAN)

### DIFF
--- a/helpers/formSchema.js
+++ b/helpers/formSchema.js
@@ -132,7 +132,7 @@ const  schema = {
         { type: 'person', personType: 'author' },
         { type: 'sectionHeading', label: 'Publication details' },
         { type: 'text', label: 'Chapter title', name: 'title', required: true, placeholder: 'Chapter title' },
-        { type: 'text', label: 'Editors name', name: 'editors', required: true, placeholder: 'Editors Name' },
+        { type: 'text', label: 'Editors\' names', name: 'editors', required: true, placeholder: 'EEditors\' names' },
         { type: 'text', label: 'Title of Book', name: 'bookTitle', required: true, placeholder: 'Title of Book' },
         { type: 'number', label: 'Publication year', name: 'year', required: true, placeholder: 'Publication year', attrs: { min: 1950 } },
         { type: 'text', label: 'Page no.', name: 'pageNos', required: true, placeholder: 'Page no.' },

--- a/helpers/formSchema.js
+++ b/helpers/formSchema.js
@@ -132,7 +132,7 @@ const  schema = {
         { type: 'person', personType: 'author' },
         { type: 'sectionHeading', label: 'Publication details' },
         { type: 'text', label: 'Chapter title', name: 'title', required: true, placeholder: 'Chapter title' },
-        { type: 'text', label: 'Editors\' name', name: 'editors', required: true, placeholder: 'Chapter title' },
+        { type: 'text', label: 'Editors name', name: 'editors', required: true, placeholder: 'Editors Name' },
         { type: 'text', label: 'Title of Book', name: 'bookTitle', required: true, placeholder: 'Title of Book' },
         { type: 'number', label: 'Publication year', name: 'year', required: true, placeholder: 'Publication year', attrs: { min: 1950 } },
         { type: 'text', label: 'Page no.', name: 'pageNos', required: true, placeholder: 'Page no.' },


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary

BUG : -  (Two input fields having same name) 
b8175dc3f01c9b928ac0f8bccba6196392e9435b

Description Of The Bug:-

While working with the Book Chapters Activity in the Submit An Activity page, two input boxes under the Publication Details section has the same placeholder, 'Chapter Title *'.

![image](https://github.com/Pursottam6003/technodaya/assets/124796350/cfb726f0-15fc-4150-8483-d61894738ed0)

Expected Behaviour:-

Instead of two 'Chapter's Title', the first input box should be named as 'Chapter's Title' and the second input box should be named as 'Editor's Name'.

Behaviour after Fixation:-

Instead of two 'Chapter's Title', the first input box is named as 'Chapter's Title' and the second input box is named as 'Editor's Name'.


![Screenshot 2023-09-19 at 2 42 11 AM](https://github.com/Pursottam6003/technodaya/assets/124796350/8dc613b3-cb3f-4c24-884c-f0408ebae9f3)

<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
…
----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
