### PR TITLE
Centring the loading svg (Team-2 AARYAN)

### DIFF
--- a/app/(admin)/admin/page.js
+++ b/app/(admin)/admin/page.js
@@ -169,7 +169,7 @@ export default function Submissions() {
       <main className={cx("workspace", styles.container)}>
         {errorApproved || errorPending ? (
           <div className="error">{errorApproved || errorPending}</div>
-        ) : fetchingPending || fetchingApproved ? <LoadingPage /> : (
+        ) : fetchingPending || fetchingApproved ?  <div className={styles["spin-center"]}><LoadingPage /> </div> : (
           <div className="submissions-wrapper">
             <div className="submission pending">
               <SubmissionSection type='pending'

--- a/app/(admin)/admin/page.module.scss
+++ b/app/(admin)/admin/page.module.scss
@@ -254,3 +254,12 @@
         white-space: nowrap;
     }
 }
+
+
+//centering spin 
+.spin-center{
+    position: absolute;
+    top: 45%;
+    left: 55%;
+
+}

--- a/components/icons/spinner-icon.js
+++ b/components/icons/spinner-icon.js
@@ -1,6 +1,6 @@
 export default function SpinnerIcon() {
   return (
-    <svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="50px" height="50px" viewBox="0 0 24 24">
+    <svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 24 24">
       <g>
         <path d="M12,2 a1,1 0 0 1 1,1 v3 a1,1 0 0 1 -1,1 a1,1 0 0 1 -1,-1 v-3 a1,1 0 0 1 1,-1 z" />
         <path style={{ opacity: .918 }} transform="rotate(330,12,12)" d="M12,2 a1,1 0 0 1 1,1 v3 a1,1 0 0 1 -1,1 a1,1 0 0 1 -1,-1 v-3 a1,1 0 0 1 1,-1 z" />

--- a/components/icons/spinner-icon.js
+++ b/components/icons/spinner-icon.js
@@ -1,6 +1,6 @@
 export default function SpinnerIcon() {
   return (
-    <svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 24 24">
+    <svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="50px" height="50px" viewBox="0 0 24 24">
       <g>
         <path d="M12,2 a1,1 0 0 1 1,1 v3 a1,1 0 0 1 -1,1 a1,1 0 0 1 -1,-1 v-3 a1,1 0 0 1 1,-1 z" />
         <path style={{ opacity: .918 }} transform="rotate(330,12,12)" d="M12,2 a1,1 0 0 1 1,1 v3 a1,1 0 0 1 -1,1 a1,1 0 0 1 -1,-1 v-3 a1,1 0 0 1 1,-1 z" />


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
BUG : - (Centring the loading svg) 
7ecc1355d340d8597f5baf0677988ab4d95b1bd9

Description Of The Bug:

While fetching the submissions, the loading animation is displayed . But this loading animation is displayed on the top left corner of the main body.

![image](https://github.com/Pursottam6003/technodaya/assets/124796350/6201307f-4e54-4739-92b6-5697547ce199)

Expected Behaviour:

The loading animation is expected to be centred and it should be compatible with all device sizes.

Behaviour After Fixation:

The loading animation is centred and is compatible with all device sizes.
<img width="1710" alt="Screenshot 2023-09-17 at 2 32 55 PM" src="https://github.com/Pursottam6003/technodaya/assets/124796350/258c9fe0-5aa3-422b-a92b-38bdcf650d69">

<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
…
----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
