### PR TITLE
Two input fields having same name issue solved by (TEAM 4 HEMANT)

### DIFF
--- a/helpers/formSchema.js
+++ b/helpers/formSchema.js
@@ -132,7 +132,7 @@ const  schema = {
         { type: 'person', personType: 'author' },
         { type: 'sectionHeading', label: 'Publication details' },
         { type: 'text', label: 'Chapter title', name: 'title', required: true, placeholder: 'Chapter title' },
-        { type: 'text', label: 'Editors\' name', name: 'editors', required: true, placeholder: 'Chapter title' },
+        { type: 'text', label: 'Editors\' name', name: 'editors', required: true, placeholder: 'Editors\' name' },
         { type: 'text', label: 'Title of Book', name: 'bookTitle', required: true, placeholder: 'Title of Book' },
         { type: 'number', label: 'Publication year', name: 'year', required: true, placeholder: 'Publication year', attrs: { min: 1950 } },
         { type: 'text', label: 'Page no.', name: 'pageNos', required: true, placeholder: 'Page no.' },


### PR DESCRIPTION
Issue :- Two input fields having same name

Description of the Issue :- While submitting an activity in Book Chapters Activity , two input boxes under the Publication Details section has the same placeholder, Chapter Title .

![Book Chapter Issue](https://github.com/Pursottam6003/technodaya/assets/126821440/759e4852-d2d6-4b3c-a4a2-12c462173f66)
Expected behavior :-
Instead of two chapters title the first input box should be named as chapters title and second input box should named as editors name.

Fixed Issue :- Replaced Chapter title at the second input box with Editor's Name.

![Book Chapter](https://github.com/Pursottam6003/technodaya/assets/126821440/f515137d-2617-4f49-9c4a-b4f028d4323b)
