### PR TITLE
Add order in select issue fixed by (TEAM 4 HEMANT)

### DIFF
--- a/components/form/form-fc.js
+++ b/components/form/form-fc.js
@@ -4,6 +4,14 @@ import { Categories } from '../../helpers/helpers'
 import styles from './Form.module.scss'
 import cx from 'classnames'
 
+const sortedcatogries = Categories.slice().sort();
+
+function originalPosition(pos) {
+  const element = sortedcatogries[pos];
+  const index = Categories.indexOf(element);
+  return index;
+}
+
 const FormFC = ({
   category, setCategory,
   activityTitle, setActivityTitle,
@@ -23,11 +31,11 @@ const FormFC = ({
     }
   }
 
-  const categoriesSelect = Categories.map((category, i) => {
+  const categoriesSelect = sortedcatogries.map((category, i) => {
     if (i === 0) {
-      return <option key={i} value={i}>Select an activity category</option>
+      return <option key={i} value={originalPosition(i)}>Select an activity category</option>
     } else {
-      return <option key={i} value={i}>{category}</option>
+      return <option key={i} value={originalPosition(i)}>{category}</option>
     }
   })
 


### PR DESCRIPTION
Issue :- Add order in select

Description of the issue :- For better user experience make ascending order in ``activity category`` options

![Order in select issue](https://github.com/Pursottam6003/technodaya/assets/126821440/6c1af142-d48b-4fd0-9857-d078af8a172f)

Expected Behavior :- The Select in ``Activity Category`` drop down list items must be in ascending order for better user experience.

Fixed Issue :- Arranged the items in ``Activity Category`` by using the inbuilt sort method and then mapped the sorted with the previous list to avoid confusion.

![Order in select](https://github.com/Pursottam6003/technodaya/assets/126821440/8cb5b189-b2ea-4395-b0ae-2403208dd926)

---